### PR TITLE
Update main.ts

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -142,8 +142,8 @@ export default class PrettierPlugin extends Plugin {
   }
 
   private getPrettierSettings = (cm: CodeMirror.Editor) => {
-    const tabWidth = cm.getOption("tabSize") || 4;
-    const useTabs = cm.getOption("indentWithTabs") ?? true;
+    const tabWidth = 4;
+    const useTabs = false;
     const embeddedLanguageFormatting = this.settings.FormatCodeBlock ? "auto": "off"
 
     return { tabWidth, useTabs,embeddedLanguageFormatting };


### PR DESCRIPTION
As per https://github.com/hipstersmoothie/obsidian-plugin-prettier/issues/9 Obsidian v0.13.23 throws error that cm.getOption does not exist.
Removing this check and just setting the values seems to work though.
Maybe adding a toggle and input field to the Plugin Setting Tab for the tabSize and indentWithTabs vaiables would be better.