### PR TITLE
Fix cursor position and remove scrolling

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -170,10 +170,13 @@ export default class PrettierPlugin extends Plugin {
       return;
     }
 
-    const { left, top } = editor.getScrollInfo();
     editor.setValue(formatted);
-    editor.setCursor(cursorOffsetToPosition(formatted, cursorOffset));
-    editor.scrollTo(left, top);
+    editor.setCursor(
+      cursorOffsetToPosition(
+        formatted,
+        fixListItemIndent(rawFormatted.slice(0, cursorOffset)).length
+      )
+    );
   };
   
   formatSelection(editor: Editor): void {


### PR DESCRIPTION
There are two changes.

# Fix `cursorOffset` in `editor.setCursor`

There is an extra step called `fixListItemIndent`, and it may remove spaces if there were lists in the Markdown file. But the variable `cursorOffset` was obtained from `prettier.formatWithCursor` and may be greater than the expected offset. As a result, the cursor position is incorrect when calling `formatAll` on a file with lists.

# Remove scrolling

`editor.scrollTo(left, top);` has no effect at all! `editor.setCursor` also scrolls the page so the cursor is always visible and it happens after `editor.scrollTo`.

To make `editor.scrollTo` effective, it can be rewritten to:

```ts
setTimeout(() => editor.scrollTo(left, top), 0);
```
But users can sometimes experience a screen blink:

1. Open a small Markdown file, which contains about 200 words.
2. Add 20 empty lines at the beginning of the file, and move the cursor to the top of the document.
3. Keep the cursor position and scroll down the page to the bottom. 
4. Formatting the whole document will make the page scroll to the top first and then instantly scroll back to the bottom, causing a blink.

I think the scolling position of `setCursor` is also acceptable, so I suggest removing the `scrollTo` function call.
